### PR TITLE
CADENZA-36890 Add the object info to cadenza.js and sandbox.html (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `CadenzaClient#fetchObjectInfo`
 
 ## 2.8.1 - 2024-06-11
 ### Added

--- a/sandbox.html
+++ b/sandbox.html
@@ -158,15 +158,20 @@
       },
       setFilter: data => cadenzaClient.setFilter(parseFilterVariables(data.filter)),
       setLayerVisibility: data => cadenzaClient.setLayerVisibility(JSON.parse(data.layer), data.visibility === 'on'),
-      setSelection: data => cadenzaClient.setSelection(JSON.parse(data.layer), JSON.parse(data.values)),
-      addSelection: data => cadenzaClient.addSelection(JSON.parse(data.layer), JSON.parse(data.values)),
-      removeSelection: data => cadenzaClient.removeSelection(JSON.parse(data.layer), JSON.parse(data.values)),
+      setSelection: data => cadenzaClient.setSelection(JSON.parse(data.layer), JSON.parse(data.objectIds)),
+      addSelection: data => cadenzaClient.addSelection(JSON.parse(data.layer), JSON.parse(data.objectIds)),
+      removeSelection: data => cadenzaClient.removeSelection(JSON.parse(data.layer), JSON.parse(data.objectIds)),
       createGeometry: data => cadenzaClient.createGeometry(data.embeddingTargetId, data.geometryType, getOptions(data)),
       editGeometry: ({ geometry, ...data }) => cadenzaClient.editGeometry(data.embeddingTargetId, JSON.parse(geometry), getOptions(data)),
       selectObjects: data => cadenzaClient.selectObjects(data.embeddingTargetId, getOptions(data)),
       fetchData: data => {
         console.log('Inspect the fetchData() request in the devtools.');
         cadenzaClient.fetchData(data.embeddingTargetId, data.dataType, getOptions(data));
+      },
+      fetchObjectInfo: data => {
+        console.log('Inspect the fetchObjectInfo() request in the devtools.');
+        cadenzaClient.fetchObjectInfo(data.embeddingTargetId, JSON.parse(data.layer), JSON.parse(data.objectIds), getOptions(data))
+          .then(oi => console.log(oi));
       },
       downloadData: data => cadenzaClient.downloadData(data.embeddingTargetId, data.dataType, getOptions(data))
     };
@@ -212,7 +217,8 @@
       parts,
       layers,
       simplifiedOperationMode,
-      useMapSrs
+      useMapSrs,
+      fullGeometries
     }) {
       return {
         disabledUiFeatures: disabledUiFeatures && disabledUiFeatures.split(','),
@@ -231,7 +237,8 @@
         parts: parts && parts.split(','),
         ...(simplifiedOperationMode === 'on' && { operationMode: 'simplified' }),
         layers: layers ? JSON.parse(layers) : undefined,
-        useMapSrs: useMapSrs === 'on'
+        useMapSrs: useMapSrs === 'on',
+        fullGeometries: fullGeometries === 'on'
       };
     }
 
@@ -280,6 +287,7 @@
           <optgroup label="Without Iframe">
             <option value="downloadData">Download data</option>
             <option value="fetchData">Fetch data</option>
+            <option value="fetchObjectInfo">Fetch Object Info</option>
           </optgroup>
         </select>
       </div>
@@ -513,9 +521,9 @@
   </div>
 </template>
 
-<template data-action="setSelection" data-common="layer,layer-selection"></template>
-<template data-action="addSelection" data-common="layer,layer-selection"></template>
-<template data-action="removeSelection" data-common="layer,layer-selection"></template>
+<template data-action="setSelection" data-common="layer,object-ids"></template>
+<template data-action="addSelection" data-common="layer,object-ids"></template>
+<template data-action="removeSelection" data-common="layer,object-ids"></template>
 
 <template data-action="reload">
   <div>
@@ -527,12 +535,12 @@
 </template>
 <template data-action="closeMe">No Parameters needed.</template>
 
-<template id="common-layer-selection">
+<template id="common-object-ids">
   <div>
-    <label for="values">List of Object IDs *</label>
-    <textarea name="values" id="values" rows="5" required></textarea>
+    <label for="objectids">List of object ID value lists *</label>
+    <textarea name="objectIds" id="objectids" rows="5" required></textarea>
     <small>
-      <p>A JSON value like <code>["object1","object2"]</code></p>
+      <p>A JSON value like <code>[["&lt;object1-id&gt;"],["&lt;object2-id&gt;"]]</code></p>
     </small>
   </div>
 </template>
@@ -565,6 +573,25 @@
   <div>
     <label for="embeddingTargetId">Embedding target ID *</label>
     <input name="embeddingTargetId" id="embeddingTargetId" required>
+  </div>
+</template>
+
+<template data-action="fetchObjectInfo" data-common="layer,object-ids,filter">
+  <div>
+    <label for="embeddingTargetId">Embedding target ID *</label>
+    <input name="embeddingTargetId" id="embeddingTargetId" required>
+  </div>
+  <div>
+    <label>
+      <input type="checkbox" name="useMapSrs">
+      Use map SRS
+    </label>
+  </div>
+  <div>
+    <label>
+      <input type="checkbox" name="fullGeometries">
+      Return the non-simplified geometries
+    </label>
   </div>
 </template>
 

--- a/src/cadenza.js
+++ b/src/cadenza.js
@@ -133,6 +133,18 @@ globalThis.cadenza = Object.assign(
  * _Note:_ Since numbers in JavaScript are Double values ([more info on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding)),
  * for Long variables, the API is currently limited to the Double value range.
  */
+/**
+ * @typedef Feature - A adapted [GeoJSON](https://geojson.org/) feature object.
+ * @property {any[]} objectId - The id of the feature
+ * @property {Geometry} geometry - The geometry
+ * @property {Record<string, string>} properties - The formated properties
+ * @property {number} [area] - The area of a `Polygon` feature
+ * @property {number} [length] - The area of a `LineString` feature
+ */
+/**
+ * @typedef FeatureCollection - A adapted [GeoJSON](https://geojson.org/) feature collection object
+ * @property {Feature[]} features - The features within this collection
+ */
 
 let hasCadenzaSession = false;
 
@@ -424,7 +436,7 @@ export class CadenzaClient {
    *
    * @hidden
    * @param {WorkbookLayerPath | string} layer - The data view layer to set the selection in
-   * @param {unknown[]} values - The IDs of the objects to select
+   * @param {unknown[][]} values - The IDs of the objects to select
    * @return {Promise<void>} A `Promise` for when the selection was set.
    */
   setSelection(layer, values) {
@@ -437,7 +449,7 @@ export class CadenzaClient {
    *
    * @hidden
    * @param {WorkbookLayerPath | string} layer - The data view layer to change the selection in
-   * @param {unknown[]} values - The IDs of the objects to select
+   * @param {unknown[][]} values - The IDs of the objects to select
    * @return {Promise<void>} A `Promise` for when the selection was changed.
    */
   addSelection(layer, values) {
@@ -450,7 +462,7 @@ export class CadenzaClient {
    *
    * @hidden
    * @param {WorkbookLayerPath | string} layer - The data view layer to change the selection in
-   * @param {unknown[]} values - The IDs of the objects to unselect
+   * @param {unknown[][]} values - The IDs of the objects to unselect
    * @return {Promise<void>} A `Promise` for when the selection was changed.
    */
   removeSelection(layer, values) {
@@ -804,14 +816,64 @@ export class CadenzaClient {
     return this.#fetch(resolvePath(source), params, signal);
   }
 
+  /**
+   * Fetch object info from a workbook map view.
+   *
+   * @param {EmbeddingTargetId} source - The workbook view to fetch object info from.
+   * @param {(WorkbookLayerPath | string)[]} layerPath - Layer path to identify the layer
+   *  (identified using layer paths or print names)
+   * @param {unknown[][]} objectIds - The IDs of the objects to select
+   * @param {object} [options] - Options
+   * @param {FilterVariables} [options.filter] - Filter variables
+   * @param {AbortSignal} [options.signal] - A signal to abort the data fetching
+   * @param {Boolean} [options.useMapSrs] - Use the map SRS instead of WGS84
+   * @param {Boolean} [options.fullGeometries] - Return non-simplified geometries
+   * @return {Promise<FeatureCollection>} A `Promise` for the fetch response
+   * @throws For invalid arguments
+   */
+  fetchObjectInfo(
+    source,
+    layerPath,
+    objectIds,
+    { filter, signal, useMapSrs, fullGeometries } = {},
+  ) {
+    this.#log('CadenzaClient#fetchObjectInfo', ...arguments);
+    const params = createParams({
+      filter,
+    });
+    return this.#fetch(
+      resolvePath(source) + '/objectinfo',
+      params,
+      signal,
+      JSON.stringify({
+        objectIds,
+        layerPath: array(layerPath),
+        useMapSrs,
+        fullGeometries,
+      }),
+    ).then((response) => response.json());
+  }
+
   async #fetch(
     /** @type string */ path,
     /** @type URLSearchParams */ params,
     /** @type AbortSignal | undefined */ signal,
+    /** @type String | undefined If body is set, the fetch will be a post.*/ body,
   ) {
     const url = this.#createUrl(path, params);
     this.#log('Fetch', url.toString());
-    const res = await fetch(url, { signal });
+    const method = body ? 'POST' : undefined;
+    const headers = new Headers();
+    headers.set('X-Requested-With', 'XMLHttpRequest');
+    if (body) {
+      headers.set('Content-Type', 'application/json');
+    }
+    const res = await fetch(url, {
+      signal,
+      method,
+      headers,
+      body,
+    });
     if (!res.ok) {
       const errorType =
         {

--- a/src/docs.md
+++ b/src/docs.md
@@ -352,6 +352,21 @@ const tableData = await response.json();
 ...
 ```
 
+### Fetch the Object Info from a Workbook Map View
+
+<small>API: [CadenzaClient#fetchObjectInfo(./classes/CadenzaClient.html#fetchObjectInfo)</small>
+
+Download the object info from a workbook map view in JSON format. The result contains all information, that is shown in the object info within cadenza.
+
+```javascript
+const response = await cadenzaClient.fetchObjectInfo('embeddingTargetId', 'layerPrintName', [['objectId']], {
+  useMapSrs: false,
+  fullGeometries: true
+});
+
+const objectInfo = await response;
+```
+
 ### Download Data From a Workbook View
 
 <small>API: [CadenzaClient#downloadData](./classes/CadenzaClient.html#downloadData)</small>


### PR DESCRIPTION
* CADENZA-36890 Add the object info to cadenza.js and sandbox.html

* CADENZA-36890 Add documentation

* CADENZA-36890 Add to CHANGELOG.md

* CADENZA-36890 Fix the header creation

* use <> instead of {} for placeholders in docs to avoid confusion in JSON examples

* add support for dataType=pdf in CadenzaClient#downloadData and #fetchData

* chore: release v2.11.0

* include version

* CADENZA-36890 Add to CHANGELOG.md

* CADENZA-36890 Review changes

* CADENZA-36890 Review changes

* CADENZA-36890 changed the name of the feature id

* CADENZA-36890 layerPath is not optional for fetchObjectInfo

* CADENZA-36890 code format

---------

Co-authored-by: luebke <jens.luebke@disy.net>
Co-authored-by: kissel <johannes.kissel@disy.net>
Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
Co-authored-by: Andreas W. Bartels <AndreasWBartels@users.noreply.github.com>

(cherry picked from commit 768327251aed7dd0a52d55c86214acb427032dc0)