### PR TITLE
CADENZA-37227 feat: Add 'action' event, which is fired as 'action' event when clicking a postMessage action Cadenza link in views shown via `CadenzaClient#show`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `CadenzaClient#fetchAreaIntersections`
 - `CadenzaClient#fetchObjectInfo`
+- `CadenzaActionEvent`
 
 ## 2.11.0 - 2024-07-12
 ### Added

--- a/src/cadenza.js
+++ b/src/cadenza.js
@@ -291,7 +291,9 @@ export class CadenzaClient {
    * @param {AbortSignal} [options.signal] - A signal to abort the iframe loading
    * @return {Promise<void>} A `Promise` for when the iframe is loaded
    * @throws For invalid arguments
-   * @fires {@link CadenzaDrillThroughEvent}
+   * @fires
+   * - {@link CadenzaDrillThroughEvent}
+   * - {@link CadenzaActionEvent}
    * @embed
    */
   show(
@@ -377,7 +379,9 @@ export class CadenzaClient {
    * @param {AbortSignal} [options.signal] - A signal to abort the iframe loading
    * @return {Promise<void>} A `Promise` for when the iframe is loaded
    * @throws For invalid arguments
-   * @fires {@link CadenzaDrillThroughEvent}
+   * @fires
+   * - {@link CadenzaDrillThroughEvent}
+   * - {@link CadenzaActionEvent}
    * @embed
    */
   async showMap(
@@ -1279,7 +1283,8 @@ function array(/** @type unknown */ value) {
 
 // Please do not add internal event types like 'ready' here.
 /**
- * @typedef {'change:selection'
+ * @typedef {'action'
+ * | 'change:selection'
  * | 'drillThrough'
  * | 'editGeometry:ok'
  * | 'editGeometry:update'
@@ -1292,7 +1297,8 @@ function array(/** @type unknown */ value) {
 
 /**
  * @template {CadenzaEventType} T
- * @typedef {T extends 'change:selection' ? CadenzaChangeSelectionEvent
+ * @typedef {T extends 'action' ? CadenzaActionEvent
+ *  : T extends 'change:selection' ? CadenzaChangeSelectionEvent
  *  : T extends 'drillThrough' ? CadenzaDrillThroughEvent
  *  : T extends 'editGeometry:update' ? CadenzaEditGeometryUpdateEvent
  *  : T extends 'editGeometry:ok' ? CadenzaEditGeometryOkEvent
@@ -1310,6 +1316,9 @@ function array(/** @type unknown */ value) {
  * @typedef CadenzaEvent - A Cadenza `postMessage()` event
  * @property {TYPE} type - The event type
  * @property {DETAIL} detail - Optional event details (depending on the event type)
+ */
+/**
+ * @typedef {CadenzaEvent<'action', {context: string}>} CadenzaActionEvent - When the user executed a POST message action, which is defined on an external link in the Cadenza management center.
  */
 /*
  * @hidden


### PR DESCRIPTION
https://jira.disy.net/browse/CADENZA-37227

This adds a 'action' event analogously to 'drillthrough'. 'drillthrough' postmessages are sent always with a `values` object and an optional `context` string. The new `action` event only has a `context` string sent along with the pm.

'action' postmessages are sent when clicking an 'postMessage action' link. Those links are defined per External URL in the Management Center and can be used in Text, Indicator and Image views in Workbooks.