### PR TITLE
CADENZA-37227 fix: Correct changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `CadenzaActionEvent`
 
+## 2.13.0 - 2024-09-24
+
 ## 2.12.0 - 2024-09-23
 ### Added
 - `CadenzaClient#fetchAreaIntersections`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Corrected changelog for 2.13.0
+
+## 2.13.0 - 2024-09-24
+### Added
+- `CadenzaActionEvent`
 
 ## 2.12.0 - 2024-09-23
 ### Added
 - `CadenzaClient#fetchAreaIntersections`
 - `CadenzaClient#fetchObjectInfo`
-- `CadenzaActionEvent`
 
 ## 2.11.0 - 2024-07-12
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@disy/cadenza.js",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "license": "Apache-2.0",
   "repository": "github:DisyInformationssysteme/cadenza.js",
   "type": "module",


### PR DESCRIPTION
Corrects the changelog entry: A release snuck in unnoticed.