### PR TITLE
CADENZA-36955 CADENZA-37861 feat: Added `setCustomValidity()` and `Va…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `setCustomValidity()` and `ValidationMessageType` to control geometry editor validation state
 
 ## 2.13.1 - 2024-09-24
 ### Fixed

--- a/sandbox.html
+++ b/sandbox.html
@@ -181,7 +181,8 @@
         cadenzaClient.fetchAreaIntersections(data.embeddingTargetId, JSON.parse(data.layer), JSON.parse(data.geometry), getOptions(data))
           .then(console.log);
       },
-      downloadData: data => cadenzaClient.downloadData(data.embeddingTargetId, data.dataType, getOptions(data))
+      downloadData: data => cadenzaClient.downloadData(data.embeddingTargetId, data.dataType, getOptions(data)),
+      setCustomValidity: data => cadenzaClient.setCustomValidity(data.message, data.type || undefined)
     };
 
     const form = document.getElementById('form');
@@ -297,6 +298,7 @@
             <option value="createGeometry">Create Geometry</option>
             <option value="editGeometry">Edit Geometry</option>
             <option value="selectObjects">Select Objects</option>
+            <option value="setCustomValidity">Set Custom Validity</option>
           </optgroup>
           <optgroup label="Without Iframe">
             <option value="downloadData">Download data</option>
@@ -470,6 +472,20 @@
     <label for="geometry">Geometry (GeoJSON)</label>
     <textarea name="geometry" id="geometry" rows="5"></textarea>
   </div>
+</template>
+
+<template data-action="setCustomValidity">
+  <p>Requires a geometry editing UI (Create / Edit Geometry actions) to be opened first.</p>
+  <label for="message">Message</label>
+  <input type="text" name="message" id="message">
+  <label for="type">Type</label>
+  <select name="type" id="type">
+    <option selected></option>
+    <option>success</option>
+    <option>info</option>
+    <option>warning</option>
+    <option>error</option>
+  </select>
 </template>
 
 <template data-action="setFilter" data-common="filter"></template>

--- a/sandbox.html
+++ b/sandbox.html
@@ -247,7 +247,7 @@
         mapExtent: mapExtent && mapExtent.split(',').map(Number),
         minScale: minScale && Number(minScale),
         parts: parts && parts.split(','),
-        ...(simplifiedOperationMode === 'on' && { operationMode: 'simplified' }),
+        operationMode: (simplifiedOperationMode === 'on' ? 'simplified' : 'normal' ),
         layers: layers ? JSON.parse(layers) : undefined,
         useMapSrs: useMapSrs === 'on',
         fullGeometries: fullGeometries === 'on',
@@ -491,6 +491,12 @@
     </select>
   </div>
   <div>
+    <label>
+      <input type="checkbox" name="simplifiedOperationMode">
+      Simplified operation mode
+    </label>
+  </div>
+  <div>
     <label for="minScale">Minimum Scale</label>
     <input type="number" name="minScale" id="minScale">
   </div>
@@ -506,6 +512,12 @@
     <textarea name="geometry" id="geometry" rows="5" required></textarea>
   </div>
   <div>
+    <label>
+      <input type="checkbox" name="simplifiedOperationMode">
+      Simplified operation mode
+    </label>
+  </div>
+  <div>
     <label for="minScale">Minimum Scale</label>
     <input type="number" name="minScale" id="minScale">
   </div>
@@ -515,6 +527,12 @@
   <div>
     <label for="embeddingTargetId">Embedding target ID of the map view *</label>
     <input name="embeddingTargetId" id="embeddingTargetId" required>
+  </div>
+  <div>
+    <label>
+      <input type="checkbox" name="simplifiedOperationMode">
+      Simplified operation mode
+    </label>
   </div>
   <div>
     <label for="layers">Layers</label>

--- a/src/cadenza.js
+++ b/src/cadenza.js
@@ -552,6 +552,7 @@ export class CadenzaClient {
    * @param {Extent} [options.mapExtent] - A map extent to set
    * @param {number} [options.minScale] - The minimum scale where the user should work on. A warning is shown when the map is zoomed out above the threshold.
    * @param {boolean} [options.useMapSrs] - Whether the created geometry should use the map's SRS (otherwise EPSG:4326 will be used)
+   * @param {OperationMode} [options.operationMode] - The mode in which a workbook should be operated
    * @param {AbortSignal} [options.signal] - A signal to abort the iframe loading
    * @return {Promise<void>} A `Promise` for when the iframe is loaded
    * @throws For invalid arguments
@@ -564,7 +565,15 @@ export class CadenzaClient {
   createGeometry(
     backgroundMapView,
     geometryType,
-    { filter, locationFinder, mapExtent, minScale, useMapSrs, signal } = {},
+    {
+      filter,
+      locationFinder,
+      mapExtent,
+      minScale,
+      useMapSrs,
+      operationMode,
+      signal,
+    } = {},
   ) {
     this.#log('CadenzaClient#createGeometry', ...arguments);
     const params = createParams({
@@ -575,6 +584,7 @@ export class CadenzaClient {
       mapExtent,
       minScale,
       useMapSrs,
+      operationMode,
     });
     return this.#show(resolvePath(backgroundMapView), params, signal);
   }
@@ -590,6 +600,7 @@ export class CadenzaClient {
    * @param {Extent} [options.mapExtent] - A map extent to set
    * @param {number} [options.minScale] - The minimum scale where the user should work on. A warning is shown when the map is zoomed out above the threshold.
    * @param {boolean} [options.useMapSrs] - Whether the geometry is in the map's SRS (otherwise EPSG:4326 is assumed)
+   * @param {OperationMode} [options.operationMode] - The mode in which a workbook should be operated
    * @param {ZoomTarget} [options.zoomTarget] - A target Cadenza should zoom to
    * @param {AbortSignal} [options.signal] - A signal to abort the iframe loading
    * @return {Promise<void>} A `Promise` for when the iframe is loaded
@@ -610,6 +621,7 @@ export class CadenzaClient {
       minScale,
       useMapSrs,
       zoomTarget,
+      operationMode,
       signal,
     } = {},
   ) {
@@ -625,6 +637,7 @@ export class CadenzaClient {
       mapExtent,
       minScale,
       useMapSrs,
+      operationMode,
     });
     await this.#show(resolvePath(backgroundMapView), params, signal);
     if (geometry) {
@@ -646,6 +659,7 @@ export class CadenzaClient {
    * @param {string} [options.locationFinder] - A search query for the location finder
    * @param {Extent} [options.mapExtent] - A map extent to set
    * @param {boolean} [options.useMapSrs] - Whether the geometry is in the map's SRS (otherwise EPSG:4326 is assumed)
+   * @param {OperationMode} [options.operationMode] - The mode in which a workbook should be operated
    * @param {AbortSignal} [options.signal] - A signal to abort the iframe loading
    * @return {Promise<void>} A `Promise` for when the iframe is loaded
    * @throws For invalid arguments
@@ -658,7 +672,15 @@ export class CadenzaClient {
    */
   selectObjects(
     backgroundMapView,
-    { filter, layers, locationFinder, mapExtent, useMapSrs, signal } = {},
+    {
+      filter,
+      layers,
+      locationFinder,
+      mapExtent,
+      useMapSrs,
+      operationMode,
+      signal,
+    } = {},
   ) {
     this.#log('CadenzaClient#selectObjects', ...arguments);
     const params = createParams({
@@ -668,6 +690,7 @@ export class CadenzaClient {
       locationFinder,
       mapExtent,
       useMapSrs,
+      operationMode,
     });
     return this.#show(resolvePath(backgroundMapView), params, signal);
   }
@@ -1270,7 +1293,7 @@ function createParams({
     ...(locationFinder && { locationFinder }),
     ...(mapExtent && { mapExtent: mapExtent.join() }),
     ...(minScale && { minScale: String(minScale) }),
-    ...(operationMode && operationMode !== 'normal' && { operationMode }),
+    ...(operationMode && { operationMode }),
     ...(parts && { parts: parts.join() }),
     ...(targetType && { targetType }),
     ...(useMapSrs && { useMapSrs: 'true' }),

--- a/src/cadenza.js
+++ b/src/cadenza.js
@@ -162,6 +162,7 @@ globalThis.cadenza = Object.assign(
  * @typedef FeatureCollection - A adapted [GeoJSON](https://geojson.org/) feature collection object
  * @property {Feature[]} features - The features within this collection
  */
+/** @typedef {'error'|'warning'|'info'|'success'} CustomValidityType - The type of custom validity used for disclose on visual presentation and form submission behavior */
 
 let hasCadenzaSession = false;
 
@@ -646,6 +647,23 @@ export class CadenzaClient {
         zoomToGeometry,
       });
     }
+  }
+
+  /**
+   * Set custom validity state of the geometry editor in addition to the default validation state (including errors and
+   * warnings). When set to error the dialog submission is blocked.
+   * If there already is a custom state set it will override it.
+   * Passing '' will reset the custom state to undefined, meaning no custom state is displayed.
+   * If no geometry editing is started, the method call has no effect.
+   * @param {string} message The message to show in the dialog
+   * @param {CustomValidityType} [type] The type of message (defaults to 'error')
+   */
+  setCustomValidity(message, type = 'error') {
+    assert(
+      ['error', 'warning', 'info', 'success'].includes(type),
+      `Invalid validity type: ${type}`,
+    );
+    this.#postEvent('setCustomValidity', { message, type });
   }
 
   /**

--- a/src/docs.md
+++ b/src/docs.md
@@ -359,12 +359,10 @@ const tableData = await response.json();
 Fetch the object info from a workbook map view in JSON format. The result contains all information, that is shown in the object info within cadenza.
 
 ```javascript
-const response = await cadenzaClient.fetchObjectInfo('embeddingTargetId', 'layerPrintName', [['objectId']], {
+const objectInfo = await cadenzaClient.fetchObjectInfo('embeddingTargetId', 'layerPrintName', [['objectId']], {
   useMapSrs: false,
   fullGeometries: true
 });
-
-const objectInfo = response;
 ```
 
 ### Fetch the area intersection from a Workbook Map View Layer
@@ -383,12 +381,10 @@ const bufferSize = {
   lengthUnit: 'm'
 }
 
-const response = await cadenzaClient.fetchAreaIntersections('embeddingTargetId', 'layerPrintName', geometry, {
+const featureCollection = await cadenzaClient.fetchAreaIntersections('embeddingTargetId', 'layerPrintName', geometry, {
   useMapSrs: true,
   bufferSize: bufferSize
 });
-
-const featureCollection = response;
 ```
 
 ### Download Data From a Workbook View


### PR DESCRIPTION
The customer is enabled to implement additional custom validation of geometries in reaction of a `geometry:update` postMessage event sent when the user changes the geometry in a geometry editor dialog (started via `createGeometry()` or `editGeometry()` calls).

In this situation the customer can use the new `setCustomValidity(message, type)` function to add an additional error, warn, info, success state:
```
  /**
   * Set custom validity state of the geometry editor in addition to the default validation state (including errors and
   * warnings). When set to error the dialog submission is blocked.
   * If there already is a custom state set it will override it.
   * Passing '' will reset the custom state to undefined, meaning no custom state is displayed.
   * If no geometry editing is started, the method call has no effect.
   * @param message {string} The message to show in the dialog
   * @param [type] {CustomValidityType} The type of message (defaults to 'error')
   */
  setCustomValidity(message, type = 'error') {
    ...
  }
  
  /** @typedef {'error'|'warning'|'info'|'success'} CustomValidityType - The type of custom validity used for disclosing custom validity state */
```

![image](https://github.com/user-attachments/assets/e69a078d-1dbc-445f-b716-944e124d382c)
