### PR TITLE
TENT-5945 feat: Switch from semver to Cadenza version based versioning

### DIFF
--- a/.github/workflows/release-legacy.yml
+++ b/.github/workflows/release-legacy.yml
@@ -1,16 +1,20 @@
-# This workflow should only be used for version releases for Cadenza JS versions bundled with
-# Cadenza 10.2 and later. For earlier versions use the "Legacy Release" workflow.
+# This workflow should only be used for Semantic versioning based releases of Cadenza JS versions used in Cadenza 10.1
+# and earlier. Starting with 10.2 we do not use Semantic versioning in the classic way.
 
-name: Release
+name: Legacy Release (Cadenza 10.1 and earlier)
 
 on:
   workflow_dispatch:
     inputs:
-      cadenza-version:
-        type: string
-        description: |
-          Cadenza Main Version
-          (Required only to create a new .0 release (e.g. 10.2.0). Otherwise the current version is incremented.)'
+      release-type:
+        type: choice
+        description: 'Release type'
+        required: true
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
     
 
 jobs:
@@ -18,14 +22,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Validate version input
-      if: "${{ github.event.inputs.cadenza-version != '' }}"
-      run: |
-        if ! [[ '${{ github.event.inputs.cadenza-version }}' =~ ^[0-9]+\.[0-9]+$ ]]; then
-          echo "Cadenza Version must be specified in the format x.x (e.g. 10.2). Was '${{ github.event.inputs.cadenza-version }}'." >&2
-          exit 1
-        fi
-
     - uses: actions/create-github-app-token@v1
       id: app-token
       with:
@@ -53,15 +49,9 @@ jobs:
         git config --global user.name "github-actions[bot]"
 
     - name: Bump package version
-      if: "${{ github.event.inputs.cadenza-version == '' }}"
-      run: echo "NEW_VERSION=$(npm --no-git-tag-version version patch)" >> $GITHUB_ENV
-
-    - name: Bump package version (Cadenza main version release)
-      if: "${{ github.event.inputs.cadenza-version != '' }}"
-      run: echo "NEW_VERSION=${{ github.event.inputs.cadenza-version }}.0" >> $GITHUB_ENV
-
-    - name: Set release tag to 'latest'
-      run: echo "RELEASE_TAG=latest" >> $GITHUB_ENV
+      run: |
+        echo "NEW_VERSION=$(npm --no-git-tag-version version ${{ github.event.inputs.release-type }})" >> $GITHUB_ENV
+        echo "RELEASE_TAG=latest" >> $GITHUB_ENV
 
     # Update changelog unreleased section with new version
     - name: Update changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+This project uses a version scheme based on the Cadenza main version in the format x.x.y, where x.x is the Cadenza main version and y a functional change or bugfix.
 
 ## Unreleased
+### Changed
+- Base the version scheme on the Cadenza main version (starting with Cadenza 10.2). New versions have the format x.x.y, where x.x is the Cadenza main version and y a functional change or bugfix.
 
 ## 2.13.2 - 2024-10-10
 ### Added

--- a/src/docs.md
+++ b/src/docs.md
@@ -10,11 +10,16 @@ Cadenza JS is a JavaScript library to use the [disy Cadenza](https://www.disy.ne
 
 Cadenza JS is included in the Cadenza distribution in the corresponding version.
 
-Alternatively you can install the most recent version using npm:
+Alternatively you can install the most recent version for a particular Cadenza Release using npm:
 
 ```bash
-npm install @disy/cadenza.js
+npm install @disy/cadenza.js@~10.2.0 # For latest version for Cadenza 10.2 
 ```
+
+The Cadenza main version is reflected in the corresponding major and minor version of Cadenza JS (e.g. 10.2.0 for Cadenza 10.2), while the last version segment is increased for both, bugfixes and functional changes.
+
+### Cadenza 10.1 and earlier
+For Cadenza 10.1 and earlier versions Cadenza JS used did use genuine semantic versioning. Please consult the Cadenza Documentation for the corresponding major and minor version of cadenza.js.
 
 ## Usage Examples
 


### PR DESCRIPTION
Switching from semver to a Cadenza Version based versioning scheme starting with Cadenza 10.2 (cadenza.js 10.2.0):
* Every Cadenza Version has its own minor version, e.g. 10.2.5 for Cadenza 10.2
* Bugfixes and Functionality changes are both mapped by third-version-segment updates (e.g. 10.2.5 => 10.2.6)
* For minor/patch releases of earlier versions (Cadenza 10.1 and earlier) there is a second "Release Legacy" workflow.

Example image (taken from a personal fork for testing):
![image](https://github.com/user-attachments/assets/535ad250-3a42-4ac4-861f-70a9accc041a)
