### PR TITLE
 TENT-5976 Introduce *-dev versions in code and establish a "Branch off Major Version" script

### DIFF
--- a/.github/workflows/branchOffCadenzaVersion.yml
+++ b/.github/workflows/branchOffCadenzaVersion.yml
@@ -1,0 +1,66 @@
+name: Branch off Cadenza Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      cadenza-version:
+        type: string
+        required: true
+        description: |
+          Next Cadenza Main Version
+          (e.g. '10.2' for setting the main branch up for development against Cadenza 10.2. This would make 10.2.0-dev the new main branch version.)
+
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Validate version input
+      if: "${{ github.event.inputs.cadenza-version != '' }}"
+      run: |
+        if ! [[ '${{ github.event.inputs.cadenza-version }}' =~ ^[0-9]+\.[0-9]+$ ]]; then
+          echo "Cadenza Version must be specified in the format x.x (e.g. 10.2). Was '${{ github.event.inputs.cadenza-version }}'." >&2
+          exit 1
+        fi
+
+    - uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: ${{ vars.DISY_RELEASE_APP_ID }}
+        private-key: ${{ secrets.DISY_RELEASE_APP_SECRET }}
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ steps.app-token.outputs.token }}
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: package.json
+        cache: 'npm'
+    
+    # Needed for creating the tag
+    - name: Configure Git
+      run: |
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
+
+    - name: Determine branch name
+      run: echo "BRANCH_NAME=v$(npm pkg get version | tr -d \" | cut -d. -f1,2).x" >> $GITHUB_ENV
+
+    - name: Create branch for current version
+      run: git branch ${{ env.BRANCH_NAME }} main
+
+    - name: Bump package version of main
+      run: echo "NEW_VERSION=$(npm --no-git-tag-version version ${{ github.event.inputs.cadenza-version }}.0-dev)" >> $GITHUB_ENV
+
+    - name: Commit and tag changes
+      run: |
+        git add "package.json"
+        git commit -m "chore: branch off main as ${{ env.BRANCH_NAME }} and bump main version to ${{ env.NEW_VERSION }}"
+
+    - name: Push changes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: git push -u origin ${{ env.BRANCH_NAME }} && git push origin && git push --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,13 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      cadenza-version:
-        type: string
-        description: |
-          Cadenza Main Version
-          (e.g. '10.2'; Required only to create a new *.0 release, e.g. 10.2.0 for Cadenza 10.2. Otherwise the current version is incremented)
-    
+  workflow_dispatch
 
 jobs:
   release:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Validate version input
-      if: "${{ github.event.inputs.cadenza-version != '' }}"
-      run: |
-        if ! [[ '${{ github.event.inputs.cadenza-version }}' =~ ^[0-9]+\.[0-9]+$ ]]; then
-          echo "Cadenza Version must be specified in the format x.x (e.g. 10.2). Was '${{ github.event.inputs.cadenza-version }}'." >&2
-          exit 1
-        fi
-
     - uses: actions/create-github-app-token@v1
       id: app-token
       with:
@@ -49,13 +34,10 @@ jobs:
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git config --global user.name "github-actions[bot]"
 
-    - name: Bump package version
-      if: "${{ github.event.inputs.cadenza-version == '' }}"
-      run: echo "NEW_VERSION=$(npm --no-git-tag-version version patch)" >> $GITHUB_ENV
-
-    - name: Bump package version (Cadenza main version release)
-      if: "${{ github.event.inputs.cadenza-version != '' }}"
-      run: echo "NEW_VERSION=$(npm --no-git-tag-version version ${{ github.event.inputs.cadenza-version }}.0)" >> $GITHUB_ENV
+    - name: Prepare package version (e.g. 1.2.3-dev => 1.2.3)
+      run: |
+        npm --no-git-tag-version version patch                                  # Remove -dev suffix
+        echo "RELEASE_VERSION=$(npm pkg get version | tr -d \")" >> $GITHUB_ENV # Determine RELEASE_VERSION
 
     - name: Set release tag to 'latest'
       run: echo "RELEASE_TAG=latest" >> $GITHUB_ENV
@@ -65,15 +47,26 @@ jobs:
       uses: superfaceai/release-changelog-action@v2
       with:
         path-to-changelog: CHANGELOG.md
-        version: ${{ env.NEW_VERSION }}
+        version: ${{ env.RELEASE_VERSION }}
         operation: release
 
-    - name: Commit and tag changes
+    - name: Commit release and tag it
       run: |
         git add "package.json"
         git add "CHANGELOG.md"
-        git commit -m "chore: release ${{ env.NEW_VERSION }}"
-        git tag ${{ env.NEW_VERSION }}
+        git commit -m "chore: release ${{ env.RELEASE_VERSION }}"
+        git tag ${{ env.RELEASE_VERSION }}
+
+    - name: Bump package version to new dev version (e.g. 1.2.3 => 1.2.4-dev)
+      run: |
+        npm --no-git-tag-version version patch                                                              # Determine next release version
+        DEV_VERSION=$(npm pkg get version | tr -d \")-dev && echo "DEV_VERSION=$DEV_VERSION" >> $GITHUB_ENV # Determine DEV_VERSION with -dev suffix
+        npm --no-git-tag-version version $DEV_VERSION                                                       # Set main to $DEV_VERSION
+
+    - name: Commit version bump
+      run: |
+        git add "package.json"
+        git commit -m "chore: bump up version to ${{ env.DEV_VERSION }}"
 
     - name: Push changes
       env:
@@ -85,13 +78,13 @@ jobs:
       uses: superfaceai/release-changelog-action@v2
       with:
         path-to-changelog: CHANGELOG.md
-        version: ${{ env.NEW_VERSION }}
+        version: ${{ env.RELEASE_VERSION }}
         operation: read
 
     - name: Update GitHub release documentation
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: ${{ env.NEW_VERSION }}
+        tag_name: ${{ env.RELEASE_VERSION }}
         body: ${{ steps.get-changelog.outputs.changelog }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@disy/cadenza.js",
-  "version": "10.2.1",
+  "version": "10.2.3-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@disy/cadenza.js",
-      "version": "10.2.1",
+      "version": "10.2.3-dev",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "29.5.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@disy/cadenza.js",
-  "version": "10.2.2",
+  "version": "10.2.3-dev",
   "license": "Apache-2.0",
   "repository": "github:DisyInformationssysteme/cadenza.js",
   "type": "module",


### PR DESCRIPTION
See: https://im.disy.net/channel/dev-cadenzajs?msg=X8hjBfWKmu9wSDNRg

* Use the version number of the non-released version in all branches/only main branch
* Use -dev suffix for unreleased git versions
* Split-off branch creation for major releases