### PR TITLE
TENT-5976 fix: Remove v prefix for NPM RELEASE_TAG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Publish npm package
       run: |
         npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
-        npm publish --verbose --access=public --tag=v${{ env.RELEASE_TAG }}
+        npm publish --verbose --access=public --tag=${{ env.RELEASE_TAG }}
       env:
         NPM_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
 


### PR DESCRIPTION
This bug lead to NPM use a tag name "vlatest" instead of "latest".

It might be enough to remote this NPM tag on npmjs.com and update "latest" TAG to use 10.2.3 instead of 10.2.2.