### PR TITLE
No ticket (follow-up of KOMPVZ-120 ): When start listening on 'ready'…

### DIFF
--- a/src/cadenza.js
+++ b/src/cadenza.js
@@ -910,13 +910,20 @@ export class CadenzaClient {
         signal.addEventListener('abort', onabort);
       }
 
+      const cadenzaReadyEventType = 'ready';
+
       unsubscribes = [
-        this.#on('ready', () => resolve()),
+        this.#on(cadenzaReadyEventType, () => resolve()),
         this.#on('error', (/** @type {CadenzaErrorEvent} */ event) => {
           const { type, message } = event.detail;
           reject(new CadenzaError(type, message ?? 'Loading failed'));
         }),
       ];
+
+      console.log(
+        `Listening on origin '${window.location.origin}' for the '${cadenzaReadyEventType}' message of Cadenza. The listening takes place in the window`,
+        window,
+      );
     });
 
     promise


### PR DESCRIPTION
… event of Cadenza, we log the origin and the window we're listening on. We log the same things on Cadenza's side now. This shall make it easier to detect a mismatch between both which causes PostMessages to not be received.