### PR TITLE
No ticket (follow-up of KOMPVZ-120 ): When start listening on 'ready'…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project uses a version scheme based on the Cadenza main version in the format x.x.y, where x.x is the Cadenza main version and y a functional change or bugfix.
 
 ## Unreleased
+### Added
+- Log message to the console when starting to listen on the 'ready' event of Cadenza
 
 ## 10.2.12 - 2025-05-05
 ### Removed

--- a/src/cadenza.js
+++ b/src/cadenza.js
@@ -910,13 +910,20 @@ export class CadenzaClient {
         signal.addEventListener('abort', onabort);
       }
 
+      const cadenzaReadyEventType = 'ready';
+
       unsubscribes = [
-        this.#on('ready', () => resolve()),
+        this.#on(cadenzaReadyEventType, () => resolve()),
         this.#on('error', (/** @type {CadenzaErrorEvent} */ event) => {
           const { type, message } = event.detail;
           reject(new CadenzaError(type, message ?? 'Loading failed'));
         }),
       ];
+
+      console.log(
+        `Listening on origin '${this.#origin}' for the '${cadenzaReadyEventType}' event of Cadenza in the window `,
+        this.#targetWindow,
+      );
     });
 
     promise


### PR DESCRIPTION
… event of Cadenza, we log the origin and the window we're listening on. We log the same things on Cadenza's side now. This shall make it easier to detect a mismatch between both which causes PostMessages to not be received.

No ticket (follow-up of KOMPVZ-120 ): When start listening on 'ready' event of Cadenza, we log the origin and the window we're listening on. We log the same things on Cadenza's side now. This shall make it easier to detect a mismatch between both which causes PostMessages to not be received.

(cherry picked from commit 5a7d5236c79c3850c0651f65aba292e859204aa6)