### PR TITLE
CADENZA-40215 fix: German characters in the repository name break cad…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project uses a version scheme based on the Cadenza main version in the format x.x.y, where x.x is the Cadenza main version and y a functional change or bugfix.
 
 ## Unreleased
+### Fixed
+- German "Umlaute" in `webApplication` `repositoryName`
 
 ## 10.3.4 - 2025-05-16
 ### Added

--- a/src/cadenza.js
+++ b/src/cadenza.js
@@ -1296,7 +1296,7 @@ function validKebabCaseString(/** @type string */ value) {
 }
 
 function validRepositoryName(/** @type string */ value) {
-  return /^[\w -]{1,255}$/.test(value);
+  return /^[\wäöüÄÖÜß -]{1,255}$/.test(value);
 }
 
 function validBase64String(/** @type string */ value) {


### PR DESCRIPTION
…enza.js

- support German "Umlaute" in webApplication repositoryName

(cherry picked from commit 69a66763724085b788d239b24a51c67f8500a5f6)