### PR TITLE
CADENZA-40215 fix: German characters in the repository name break cad…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- German "Umlaute" in `webApplication` `repositoryName`
 
 ## 3.0.4 - 2025-03-11
 ### Changed

--- a/src/cadenza.js
+++ b/src/cadenza.js
@@ -1217,7 +1217,7 @@ function validKebabCaseString(/** @type string */ value) {
 }
 
 function validRepositoryName(/** @type string */ value) {
-  return /^[\w -]{1,255}$/.test(value);
+  return /^[\wäöüÄÖÜß -]{1,255}$/.test(value);
 }
 
 function validBase64String(/** @type string */ value) {


### PR DESCRIPTION
…enza.js

- support German "Umlaute" in webApplication repositoryName

(cherry picked from commit 69a66763724085b788d239b24a51c67f8500a5f6)