### PR TITLE
CADENZA-40418 update version to 10.4.2-dev because of a broken releas…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@disy/cadenza.js",
-  "version": "10.4.1-dev",
+  "version": "10.4.2-dev",
   "license": "Apache-2.0",
   "repository": "github:DisyInformationssysteme/cadenza.js",
   "type": "module",


### PR DESCRIPTION
…e build which resulted in version 10.4.1 already to be used in the npm registry